### PR TITLE
Add ScriptBlock support for New/Set-PSNote

### DIFF
--- a/Public/New-PSNote.ps1
+++ b/Public/New-PSNote.ps1
@@ -1,4 +1,4 @@
-﻿Function New-PSNote{
+Function New-PSNote{
     <#
     .SYNOPSIS
         Use to add or update a PSNote object
@@ -29,12 +29,12 @@
 
     .PARAMETER Force
         If Note already exists the Force switch is required to overwrite it
-
+    
     .EXAMPLE
-        New-PSNote -Note 'ADUser' -Snippet 'Get-AdUser -Filter *' -Details "Use to return all AD users" -Tags 'AD','Users'
+        New-PSNote -Note 'ADUser' -Snippet 'Get-AdUser -Filter *' -Details "Use to return all AD users" -Tags 'AD','Users' 
 
         Creates a new Note for the Get-ADUser cmdlet
-
+    
     .EXAMPLE
         $Snippet = '(Get-Culture).DateTimeFormat.GetAbbreviatedDayName((Get-Date).DayOfWeek.value__)'
         New-PSNote -Note 'DayOfWeek' -Snippet $Snippet -Details "Use to name of the day of the week" -Tags 'date' -Alias 'today'
@@ -55,8 +55,8 @@
 
     .LINK
         https://github.com/mdowst/PSNotes
-
-
+    
+    
     #>
     [cmdletbinding(SupportsShouldProcess=$true,ConfirmImpact='Low')]
     param(
@@ -74,7 +74,7 @@
         [parameter(Mandatory=$false)]
         [switch]$Force
     )
-
+	
 	# Validate that $Snippet is either a string, scriptblock, or something that can be converted into a string
     # e.g. - [int], [guid], [decimal], etc.
     if ((-not ($Snippet -is [string])) -and $Snippet -is [System.IConvertible]) {
@@ -83,14 +83,14 @@
     elseif ($Snippet -is [scriptblock]) {
         $Snippet = $Snippet.ToString().Trim()
     }
-
+	
     Function Test-NoteAlias{
         param($Alias)
-
+        
         $AliasCheck = [regex]::Matches($Alias,"[^0-9a-zA-Z\-_]")
         if($AliasCheck.Success){
             throw "'$Alias' is not a valid alias. Alias's can only contain letters, numbers, dashes(-), and underscores (_)."
-        }
+        } 
     }
     $check = $noteObjects | Where-Object{$_.Note -eq $Note}
     if($check -and -not $force){
@@ -119,11 +119,11 @@
         }
 
         Test-NoteAlias $Alias
-
+        
         $newNote = [PSNote]::New($Note, $Snippet, $Details, $Alias, $Tags)
         $noteObjects.Add($newNote)
         Set-Alias -Name $newNote.Alias -Value Get-PSNoteAlias -Scope Global
     }
-
+    
     Update-PSNotesJsonFile
 }

--- a/Public/New-PSNote.ps1
+++ b/Public/New-PSNote.ps1
@@ -1,4 +1,4 @@
-﻿Function New-PSNote {
+﻿Function New-PSNote{
     <#
     .SYNOPSIS
         Use to add or update a PSNote object
@@ -58,24 +58,24 @@
 
 
     #>
-    [cmdletbinding(SupportsShouldProcess = $true, ConfirmImpact = 'Low', PositionalBinding=$false)]
+    [cmdletbinding(SupportsShouldProcess=$true,ConfirmImpact='Low')]
     param(
-        [parameter(Mandatory = $true, Position = 0)]
+        [parameter(Mandatory=$true)]
         [string]$Note,
-        [parameter(Mandatory = $true, Position = 1)]
+        [parameter(Mandatory=$false)]
         [ValidateScript({ $_ -is [scriptblock] -or $_ -is [System.IConvertible] })]
         [object]$Snippet,
-        [parameter(Mandatory = $false)]
+        [parameter(Mandatory=$false)]
         [string]$Details,
-        [parameter(Mandatory = $false)]
+        [parameter(Mandatory=$false)]
         [string]$Alias,
-        [parameter(Mandatory = $false)]
+        [parameter(Mandatory=$false)]
         [string[]]$Tags,
-        [parameter(Mandatory = $false)]
+        [parameter(Mandatory=$false)]
         [switch]$Force
     )
 
-    # Validate that $Snippet is either a string, scriptblock, or something that can be converted into a string
+	# Validate that $Snippet is either a string, scriptblock, or something that can be converted into a string
     # e.g. - [int], [guid], [decimal], etc.
     if ((-not ($Snippet -is [string])) -and $Snippet -is [System.IConvertible]) {
         $Snippet = [System.Convert]::ToString($Snippet)
@@ -84,41 +84,37 @@
         $Snippet = $Snippet.ToString().Trim()
     }
 
-    Function Test-NoteAlias {
+    Function Test-NoteAlias{
         param($Alias)
 
-        $AliasCheck = [regex]::Matches($Alias, "[^0-9a-zA-Z\-_]")
-        if ($AliasCheck.Success) {
+        $AliasCheck = [regex]::Matches($Alias,"[^0-9a-zA-Z\-_]")
+        if($AliasCheck.Success){
             throw "'$Alias' is not a valid alias. Alias's can only contain letters, numbers, dashes(-), and underscores (_)."
         }
     }
-
-    $check = $noteObjects | Where-Object {$_.Note -eq $Note}
-    if ($check -and -not $force) {
+    $check = $noteObjects | Where-Object{$_.Note -eq $Note}
+    if($check -and -not $force){
         Write-Error "The note '$Note' already exists. Use -force to overwrite existing properties"
         break
-    }
-    elseif ($check -and $force) {
-        $noteObjects | Where-Object {$_.Note -eq $Note} | ForEach-Object {
-
-            $_.Snippet = $Snippet
-
-            if (-not [string]::IsNullOrEmpty($Details)) {
+    } elseif($check -and $force){
+        $noteObjects | Where-Object{$_.Note -eq $Note} | ForEach-Object{
+            if(-not [string]::IsNullOrEmpty($Snippet)){
+                $_.Snippet = $Snippet
+            }
+            if(-not [string]::IsNullOrEmpty($Details)){
                 $_.Details = $Details
             }
-            if (-not [string]::IsNullOrEmpty($Alias)) {
+            if(-not [string]::IsNullOrEmpty($Alias)){
                 Test-NoteAlias $Alias
                 $_.Alias = $Alias
             }
-            if (-not [string]::IsNullOrEmpty($Tags)) {
+            if(-not [string]::IsNullOrEmpty($Tags)){
                 $_.Tags = $Tags
             }
-
             $_.File = $UserPSNotesJsonFile
         }
-    }
-    else {
-        if ([string]::IsNullOrEmpty($Alias)) {
+    } else {
+        if([string]::IsNullOrEmpty($Alias)){
             $Alias = $Note
         }
 

--- a/Public/Set-PSNote.ps1
+++ b/Public/Set-PSNote.ps1
@@ -12,7 +12,7 @@ Function Set-PSNote {
         The note you want to add/update.
 
     .PARAMETER Snippet
-        The text of the snippet to add/update.
+        The text or scriptblock of the snippet to add/update.
 
     .PARAMETER Details
         The Details of the snippet to add/update.

--- a/Public/Set-PSNote.ps1
+++ b/Public/Set-PSNote.ps1
@@ -1,4 +1,4 @@
-Function Set-PSNote {
+Function Set-PSNote{
     <#
     .SYNOPSIS
         Use to add or update a PSNote object
@@ -26,12 +26,12 @@ Function Set-PSNote {
 
     .PARAMETER Tags
         A string array of tags to add/update for the Note
-
+    
     .EXAMPLE
-        Set-PSNote -Note 'ADUser' -Tags 'AD','Users'
+        Set-PSNote -Note 'ADUser' -Tags 'AD','Users' 
 
         Set the tags AD and User for the note ADUser
-
+    
     .EXAMPLE
         $Snippet = '(Get-Culture).DateTimeFormat.GetAbbreviatedDayName((Get-Date).DayOfWeek.value__)'
         Set-PSNote -Note 'DayOfWeek' -Snippet $Snippet
@@ -40,28 +40,28 @@ Function Set-PSNote {
 
     .LINK
         https://github.com/mdowst/PSNotes
-
-
+    
+    
     #>
-    [cmdletbinding(SupportsShouldProcess = $true, ConfirmImpact = 'Low', PositionalBinding = $false)]
+    [cmdletbinding(SupportsShouldProcess=$true,ConfirmImpact='Low')]
     param(
-        [parameter(Mandatory = $true, Position = 0)]
+        [parameter(Mandatory=$true)]
         [string]$Note,
-        [parameter(Mandatory = $true, Position = 1)]
+        [parameter(Mandatory=$false)]
         [ValidateScript({ $_ -is [scriptblock] -or $_ -is [System.IConvertible] })]
         [object]$Snippet,
-        [parameter(Mandatory = $false)]
+        [parameter(Mandatory=$false)]
         [string]$Details,
-        [parameter(Mandatory = $false)]
+        [parameter(Mandatory=$false)]
         [string]$Alias,
-        [parameter(Mandatory = $false)]
+        [parameter(Mandatory=$false)]
         [string[]]$Tags
     )
 
-    $check = $noteObjects | Where-Object {$_.Note -eq $Note}
-    if (-not $check) {
+    $check = $noteObjects | Where-Object{$_.Note -eq $Note}
+    if(-not $check){
         Write-Warning "The note '$Note' does not exists. An attempt will be made to create it."
-    }
+    } 
 
     New-PSNote @PSBoundParameters -Force
 }

--- a/Public/Set-PSNote.ps1
+++ b/Public/Set-PSNote.ps1
@@ -1,4 +1,4 @@
-Function Set-PSNote{
+Function Set-PSNote {
     <#
     .SYNOPSIS
         Use to add or update a PSNote object
@@ -26,12 +26,12 @@ Function Set-PSNote{
 
     .PARAMETER Tags
         A string array of tags to add/update for the Note
-    
+
     .EXAMPLE
-        Set-PSNote -Note 'ADUser' -Tags 'AD','Users' 
+        Set-PSNote -Note 'ADUser' -Tags 'AD','Users'
 
         Set the tags AD and User for the note ADUser
-    
+
     .EXAMPLE
         $Snippet = '(Get-Culture).DateTimeFormat.GetAbbreviatedDayName((Get-Date).DayOfWeek.value__)'
         Set-PSNote -Note 'DayOfWeek' -Snippet $Snippet
@@ -40,27 +40,28 @@ Function Set-PSNote{
 
     .LINK
         https://github.com/mdowst/PSNotes
-    
-    
+
+
     #>
-    [cmdletbinding(SupportsShouldProcess=$true,ConfirmImpact='Low')]
+    [cmdletbinding(SupportsShouldProcess = $true, ConfirmImpact = 'Low', PositionalBinding = $false)]
     param(
-        [parameter(Mandatory=$true)]
+        [parameter(Mandatory = $true, Position = 0)]
         [string]$Note,
-        [parameter(Mandatory=$false)]
-        [string]$Snippet,
-        [parameter(Mandatory=$false)]
+        [parameter(Mandatory = $true, Position = 1)]
+        [ValidateScript({ $_ -is [scriptblock] -or $_ -is [System.IConvertible] })]
+        [object]$Snippet,
+        [parameter(Mandatory = $false)]
         [string]$Details,
-        [parameter(Mandatory=$false)]
+        [parameter(Mandatory = $false)]
         [string]$Alias,
-        [parameter(Mandatory=$false)]
+        [parameter(Mandatory = $false)]
         [string[]]$Tags
     )
 
-    $check = $noteObjects | Where-Object{$_.Note -eq $Note}
-    if(-not $check){
+    $check = $noteObjects | Where-Object {$_.Note -eq $Note}
+    if (-not $check) {
         Write-Warning "The note '$Note' does not exists. An attempt will be made to create it."
-    } 
+    }
 
     New-PSNote @PSBoundParameters -Force
 }

--- a/Resources/PSNote_Classes.ps1
+++ b/Resources/PSNote_Classes.ps1
@@ -20,7 +20,7 @@ class PSNote {
         $this.Alias = $Alias
         $this.Tags = $Tags
         $this.File = $script:UserPSNotesJsonFile
-
+        
         if([string]::IsNullOrEmpty($Alias)){
             $this.Alias = $Note
         }

--- a/Resources/PSNote_Classes.ps1
+++ b/Resources/PSNote_Classes.ps1
@@ -7,6 +7,8 @@ class PSNote {
     [string[]]$Tags
     [string]$file
 
+    PSNote() {}
+
     PSNote(
         [string]$Note,
 		[string]$Snippet,

--- a/Resources/PSNote_Classes.ps1
+++ b/Resources/PSNote_Classes.ps1
@@ -9,18 +9,23 @@ class PSNote {
 
     PSNote(
         [string]$Note,
-		[string]$Snippet,
+		[object]$Snippet,
 		[string]$Details,
         [string]$Alias,
         [string[]]$Tags
     ){
         $this.Note = $Note
-		$this.Snippet = $Snippet
+        if ($Snippet -is [scriptblock]) {
+            $this.Snippet = $Snippet.ToString().Trim()
+        }
+        else {
+            $this.Snippet = $Snippet
+        }
 		$this.Details = $Details
         $this.Alias = $Alias
         $this.Tags = $Tags
         $this.File = $script:UserPSNotesJsonFile
-        
+
         if([string]::IsNullOrEmpty($Alias)){
             $this.Alias = $Note
         }

--- a/Resources/PSNote_Classes.ps1
+++ b/Resources/PSNote_Classes.ps1
@@ -7,8 +7,6 @@ class PSNote {
     [string[]]$Tags
     [string]$file
 
-    PSNote() {}
-
     PSNote(
         [string]$Note,
 		[string]$Snippet,
@@ -17,7 +15,7 @@ class PSNote {
         [string[]]$Tags
     ){
         $this.Note = $Note
-        $this.Snippet = $Snippet
+		$this.Snippet = $Snippet
 		$this.Details = $Details
         $this.Alias = $Alias
         $this.Tags = $Tags

--- a/Resources/PSNote_Classes.ps1
+++ b/Resources/PSNote_Classes.ps1
@@ -9,18 +9,13 @@ class PSNote {
 
     PSNote(
         [string]$Note,
-		[object]$Snippet,
+		[string]$Snippet,
 		[string]$Details,
         [string]$Alias,
         [string[]]$Tags
     ){
         $this.Note = $Note
-        if ($Snippet -is [scriptblock]) {
-            $this.Snippet = $Snippet.ToString().Trim()
-        }
-        else {
-            $this.Snippet = $Snippet
-        }
+        $this.Snippet = $Snippet
 		$this.Details = $Details
         $this.Alias = $Alias
         $this.Tags = $Tags


### PR DESCRIPTION
This change would allow the -Snippet parameter to have strings (or anything that can be converted to one) and scriptblock objects as input.

Any scriptblock input would converted to a string with any leading or trailing whitespace trimmed.