### PR TITLE
Script path patch

### DIFF
--- a/src/Classes/NoteStore.class.ps1
+++ b/src/Classes/NoteStore.class.ps1
@@ -89,16 +89,25 @@ class PSNote {
         if ([bool]::TryParse($objRun, [ref]$tryRun)) { $this.Run = $tryRun } else { $this.Run = $false }
 
         # --- Kind (new, but tolerate missing/invalid) ---
-        $kindText = $null
+        $kindValue = $null
         if ($null -ne $object.PSObject.Properties['Kind']) {
-            $kindText = [string]$object.Kind
+            $kindValue = $object.Kind
         }
 
-        if ([string]::IsNullOrWhiteSpace($kindText)) {
+        if ($null -eq $kindValue) {
             $this.Kind = [PSNoteKind]::Snippet
         }
         else {
-            try { $this.Kind = [PSNoteKind]::$kindText }
+            try {
+                # Handle both string names and int values (0, 1)
+                $intValue = 0
+                if ([int]::TryParse([string]$kindValue, [ref]$intValue)) {
+                    $this.Kind = [PSNoteKind]$intValue
+                }
+                else {
+                    $this.Kind = [PSNoteKind]::$kindValue
+                }
+            }
             catch { $this.Kind = [PSNoteKind]::Snippet }
         }
     }

--- a/src/PSNotes.psd1
+++ b/src/PSNotes.psd1
@@ -12,7 +12,7 @@
     RootModule            = '.\PSNotes.psm1'
 
     # Version number of this module.
-    ModuleVersion         = '1.0.0'
+    ModuleVersion         = '1.0.1'
 
     # Supported PSEditions
     CompatiblePSEditions = @('Desktop','Core')

--- a/src/Private/Invoke-PSNote.ps1
+++ b/src/Private/Invoke-PSNote.ps1
@@ -24,7 +24,6 @@ Executes the provided note.
     Returns any output from the executed script or snippet.
 #>
 Function Invoke-PSNote {
-
     [cmdletbinding(DefaultParameterSetName = "Note")]
     param(      
         [parameter(Mandatory = $true, ParameterSetName = "Note", Position = 0)]
@@ -34,13 +33,21 @@ Function Invoke-PSNote {
     
     switch ($Note.Kind) {
         Script {
-            if ([string]::IsNullOrWhiteSpace($Note.Snippet)) {
+            $scriptPath = $Note.Snippet
+            if (-not [string]::IsNullOrWhiteSpace($scriptPath)) {
+                $scriptPath = $scriptPath.Trim()
+            }
+
+            if ([string]::IsNullOrWhiteSpace($scriptPath)) {
                 throw "Cannot invoke Script note '$($Note.Name)': Path is empty."
             }
-            if (-not (Test-Path -LiteralPath $Note.Snippet)) {
-                throw "Cannot invoke Script note '$($Note.Name)': Script file not found at path: $($Note.Snippet)"
+
+            if (-not (Test-Path -LiteralPath $scriptPath -PathType Leaf)) {
+                throw "Cannot invoke Script note '$($Note.Name)': Script file not found at path: $scriptPath"
             }
-            & $Note.Snippet
+
+            $resolvedScriptPath = (Get-Item -LiteralPath $scriptPath -ErrorAction Stop).FullName
+            & $resolvedScriptPath
         }
         Snippet {
             if ([string]::IsNullOrWhiteSpace($Note.Snippet)) {

--- a/tests/UnitTests/Get-PSNoteAlias.Tests.ps1
+++ b/tests/UnitTests/Get-PSNoteAlias.Tests.ps1
@@ -88,6 +88,17 @@ Describe "Get-PSNoteAlias" {
             TestScriptPath | Should -Be 'Hello Pester'
         }
 
+        It "executes a script note when the script path contains spaces" {
+            $scriptDirWithSpaces = Join-Path $script:TestDir 'Folder With Spaces'
+            $null = New-Item -Path $scriptDirWithSpaces -ItemType Directory -Force
+            $scriptFile = Join-Path $scriptDirWithSpaces 'Test Script Path.ps1'
+            Set-Content -Path $scriptFile -Value '"Hello Space Path"' -Force
+
+            New-PSNote -Name 'TestScriptPathWithSpaces' -ScriptPath $scriptFile -Details 'Test script path with spaces' -Catalog 'TestScriptStore' -Alias 'TestScriptPathWithSpaces'
+
+            TestScriptPathWithSpaces | Should -Be 'Hello Space Path'
+        }
+
         It "copies to clipboard without executing when -Copy is used" {
             $scriptFile = Join-Path $script:TestDir 'TestScriptPath.ps1'
             Set-Content -Path $scriptFile -Value '"Hello Pester"' -Force


### PR DESCRIPTION
Fixed issue where scripts in paths with white space failed to run.
Fixed kind parsing in the PSNotes constructor when the JSON object saved the kind as a number.

#10 